### PR TITLE
make matrix multiplications a bit differently in case of no shaders

### DIFF
--- a/src/libphigs/wsgl/wsgl_extattr.c
+++ b/src/libphigs/wsgl/wsgl_extattr.c
@@ -148,7 +148,6 @@ void wsgl_setup_back_int_attr_nocol(
  * NOTES:	Make sure to enable GL_COLOR_MATERIAL before use
  * RETURNS:     N/A
  */
-/*
 void wsgl_setup_int_refl_props(
    Pint colr_type,
    Pcoval *colr,
@@ -240,7 +239,6 @@ void wsgl_setup_int_refl_props(
          break;
    }
 }
-*/
 
 /*******************************************************************************
  * wsgl_setup_back_int_refl_props

--- a/src/libphigs/wsgl/wsgl_light.c
+++ b/src/libphigs/wsgl/wsgl_light.c
@@ -353,6 +353,7 @@ void wsgl_update_light_src_state(
    Phg_ret ret;
    Wsgl *wsgl = ws->render_context;
 
+   glPushMatrix();
    glLoadIdentity();
 
    /* Activate light sources */


### PR DESCRIPTION
This patch introduces a few bug fixes for the case where there are no shaders.