### PR TITLE
add new functions to set the hardcopy scale factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,6 @@ Notes:
  * There is no support for PostScript at the moment.
  * The hardcopy types are available in Fortran. C-Bindings have not been tested with them
 
-### (Extension) Display/Color
-There is some support for transparency.
-* PSALCH(REAL VALUE): set ALPHA channel to Value. Value is between 0(fully transparent) and 1 (opaque). Added to the current structure.
-* pset_alpha_channel(float value): C-Binding for PSALCH. Added to the current structure.
-
 ### Input devices
 Openphigs behaviour on echo modes is summarized below.
 
@@ -137,9 +132,21 @@ Extensions:
   * as 4 but
   * echo area is given as a fraction of the root window
 
+## Extensions
+### There is some support for transparency.
+#### Fortran bindings
+* PXNDEF(STRING NAME): set the configuration location and file name
+* PXHCSF(INTEGER IWK, REAL VALUE): Set hardcopy scale factor for workstation ID WKID. Must be set before the workstation is being opened
+
+* PSALCH(REAL VALUE): set ALPHA channel to Value. Value is between 0(fully transparent) and 1 (opaque). Added to the current structure.
+#### C-bindings
+* pxset_conf_file_name(char* path): set the configuration location and file name
+* pxset_conf_hcsf(WKID, float value): Set hardcopy scale factor for workstation ID WKID. Must be set before the workstation is being opened
+
+* pset_alpha_channel(float value): C-Binding for PSALCH. Added to the current structure.
+
 ## Versions
 * 0.0.1-1: Revised code from upstream
-* 0.0.2-1: Implement additional extend C and Fortran bindings for CERN specific purposes
 * 0.0.2-1: Implement additional extend C and Fortran bindings for CERN specific purposes
 * v0.1-1:  Fixes for exotic hardware
 * v0.2-1:  Introduce scale factor for hardcopies

--- a/src/include/phigs/phigs.h
+++ b/src/include/phigs/phigs.h
@@ -4144,6 +4144,29 @@ void pmessage(
 	      char* message
 	      );
 
+/*******************************************************************************
+ * Extension: set config file name
+ *
+ * DESCR:       set config file name
+ * RETURNS:     N/A
+ * Note: extending the standard
+ */
+void pxset_conf_file_name(
+			  char * name
+			  );
+  
+/*******************************************************************************
+* Extension: set hardcopy scale factor
+*
+* DESCR:       set harcopy scale factor for workstation
+* RETURNS:     N/A
+* Note: extending the standard
+*/
+void pxset_conf_hcsf(
+		     Pint wkid,
+		     Pfloat hcsf
+		     );
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/libphigs/c_binding/cb_conf.c
+++ b/src/libphigs/c_binding/cb_conf.c
@@ -19,9 +19,34 @@
 *******************************************************************************/
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include "phconf.h"
 
-/* configuration file name */
-void pxset_conf_file_name(char * name) {
+/*******************************************************************************
+ * pxset_conf_file_name
+ *
+ * DESCR:       set the configuration path and name
+ * RETURNS:     N/A
+ */
+void pxset_conf_file_name(
+			  char * name)
+{
   read_config(name);
+}
+
+
+void pxset_conf_hcsf(
+		Pint wkid,
+		Pfloat hcsf
+		){
+  if (wkid >=0 && wkid <100){
+    if (hcsf > 0. && hcsf <= 32){
+      config[wkid].hcsf = hcsf;
+    } else {
+      printf("ERROR: configuration error. Ignoring unreasonable scale factor of: %f\n", hcsf);
+    }
+  } else {
+    printf("FATAL: configuration error. Work station ID out of range: %d\n", wkid);
+    exit(1);
+  }
 }

--- a/src/libphigs/f_binding/fb_conf.c
+++ b/src/libphigs/f_binding/fb_conf.c
@@ -49,3 +49,19 @@ FTN_SUBROUTINE(pxndef)(
     printf("WARNING: Configuration file name is too long\n");
   }
 }
+
+/*******************************************************************************
+ * pxhcsf
+ *
+ * DESCR:       set the hardcopy scale factor for workstation
+ * RETURNS:     N/A
+ */
+FTN_SUBROUTINE(pxhcsf)(
+		      FTN_INTEGER(wkid),
+		      FTN_REAL(hcsf)
+		       )
+{
+  Pint ws_id = FTN_INTEGER_GET(wkid);
+  Pfloat hc_sf = FTN_REAL_GET(hcsf);
+  pxset_conf_hcsf(ws_id, hc_sf);
+}


### PR DESCRIPTION
It would be nice if it was possible to configure at least some of the things which are currently in the configuration file programmatically. Specifically, for hardcopies it may be convenient to be able to specify the resolution via the scale factor.
Other things may be useful as well. 
Things which have been set programmatically explicitly  should have preference over what is specified in the configuration file.

