### PR TITLE
Fix transparent surfaces occlusion (Issue #34)

### DIFF
--- a/src/include/phigs/private/wsglP.h
+++ b/src/include/phigs/private/wsglP.h
@@ -289,7 +289,8 @@ extern "C" {
 
   void wsgl_set_colr(
                      Pint colr_type,
-                     Pcoval *colr
+                     Pcoval *colr,
+                     Pfloat alpha
                      );
 
   /*******************************************************************************

--- a/src/include/phigs/private/wsglP.h
+++ b/src/include/phigs/private/wsglP.h
@@ -198,6 +198,17 @@ extern "C" {
   void wsgl_clear_geometry();
 
   /*******************************************************************************
+  /*******************************************************************************
+   * wsgl_set_transparency_pass
+   *
+   * DESCR:       Set the transparency pass and update HLHSR depth mask.
+   * RETURNS:     N/A
+   */
+  void wsgl_set_transparency_pass(Ws *ws, int pass);
+
+  extern int wsgl_current_transparency_pass;
+
+  /*******************************************************************************
    * wsgl_init
    *
    * DESCR:       Initialize renderer

--- a/src/include/phigs/private/wsglP.h
+++ b/src/include/phigs/private/wsglP.h
@@ -360,6 +360,10 @@ extern "C" {
                             Ws *ws
                             );
 
+  void wsgl_init_rendering_state(
+                            Ws *ws
+                            );
+
   /*******************************************************************************
    * wsgl_end_rendering
    *

--- a/src/libphigs/ws/wsb.c
+++ b/src/libphigs/ws/wsb.c
@@ -854,7 +854,8 @@ void phg_wsb_traverse_all_postings(
 
   WSB_CHECK_POSTED(&owsb->posted);
   if( WSB_SOME_POSTED(&owsb->posted) ) {
-    /* Set up for complete traversal. */
+    /* PASS 1: Opaque elements */
+    wsgl_set_transparency_pass(ws, 0);
     post_str = owsb->posted.lowest.higher;
     end = &(owsb->posted.highest);
     wsgl_begin_rendering(ws);
@@ -863,6 +864,20 @@ void phg_wsb_traverse_all_postings(
       post_str = post_str->higher;
     }
     wsgl_end_rendering(ws);
+
+    /* PASS 2: Transparent elements (drawn with depth write off) */
+    wsgl_set_transparency_pass(ws, 1);
+    post_str = owsb->posted.lowest.higher;
+    wsgl_begin_rendering(ws);
+    while ( post_str != end ) {
+      phg_wsb_traverse_net( ws, post_str->structh );
+      post_str = post_str->higher;
+    }
+    wsgl_end_rendering(ws);
+
+    /* Restore default state (Opaque) */
+    wsgl_set_transparency_pass(ws, 0);
+
     owsb->surf_state = PSURF_NOT_EMPTY;
   }
 }

--- a/src/libphigs/ws/wsb.c
+++ b/src/libphigs/ws/wsb.c
@@ -854,25 +854,26 @@ void phg_wsb_traverse_all_postings(
 
   WSB_CHECK_POSTED(&owsb->posted);
   if( WSB_SOME_POSTED(&owsb->posted) ) {
+    wsgl_begin_rendering(ws);
+
     /* PASS 1: Opaque elements */
     wsgl_set_transparency_pass(ws, 0);
     post_str = owsb->posted.lowest.higher;
     end = &(owsb->posted.highest);
-    wsgl_begin_rendering(ws);
     while ( post_str != end ) {
       phg_wsb_traverse_net( ws, post_str->structh );
       post_str = post_str->higher;
     }
-    wsgl_end_rendering(ws);
 
     /* PASS 2: Transparent elements (drawn with depth write off) */
     wsgl_set_transparency_pass(ws, 1);
     post_str = owsb->posted.lowest.higher;
-    wsgl_begin_rendering(ws);
+    wsgl_init_rendering_state(ws);
     while ( post_str != end ) {
       phg_wsb_traverse_net( ws, post_str->structh );
       post_str = post_str->higher;
     }
+    
     wsgl_end_rendering(ws);
 
     /* Restore default state (Opaque) */

--- a/src/libphigs/wsgl/wsgl.c
+++ b/src/libphigs/wsgl/wsgl.c
@@ -49,6 +49,19 @@ short int wsgl_use_shaders = 1;
 short int wsgl_vert_shader_version = 120;
 short int wsgl_frag_shader_version = 120;
 
+int wsgl_current_transparency_pass = 0;
+
+/*******************************************************************************
+ * wsgl_set_transparency_pass
+ *
+ * DESCR:       Set the transparency pass and update HLHSR depth mask.
+ * RETURNS:     N/A
+ ******************************************************************************/
+void wsgl_set_transparency_pass(Ws *ws, int pass) {
+    wsgl_current_transparency_pass = pass;
+    wsgl_update_hlhsr_id(ws);
+}
+
 #define LOG_INT(DATA)                                   \
   css_print_eltype(ELMT_HEAD(DATA)->elementType);       \
   printf(":\tSIZE: %d\t", ELMT_HEAD(DATA)->length);     \

--- a/src/libphigs/wsgl/wsgl.c
+++ b/src/libphigs/wsgl/wsgl.c
@@ -386,7 +386,7 @@ void wsgl_flush(
  * DESCR:       Initialize rendering state helper function
  * RETURNS:     N/A
  */
-static void init_rendering_state(
+void wsgl_init_rendering_state(
                                  Ws *ws
                                  )
 {
@@ -459,7 +459,7 @@ void wsgl_begin_rendering(
   }
   glDepthMask (GL_TRUE);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-  init_rendering_state(ws);
+  wsgl_init_rendering_state(ws);
 }
 
 /*******************************************************************************

--- a/src/libphigs/wsgl/wsgl.c
+++ b/src/libphigs/wsgl/wsgl.c
@@ -1465,7 +1465,7 @@ void wsgl_begin_pick(
   printf("\n");
 #endif
 
-  init_rendering_state(ws);
+  wsgl_init_rendering_state(ws);
   glSelectBuffer(wsgl->select_size, wsgl->select_buf);
 #ifdef DEBUGINP
   printf("WSGL begin pick: set render mode to select\n");

--- a/src/libphigs/wsgl/wsgl_attr.c
+++ b/src/libphigs/wsgl/wsgl_attr.c
@@ -364,7 +364,11 @@ void wsgl_update_hlhsr_id(
 
   case PHIGS_HLHSR_ID_ON:
     glDepthFunc(GL_LESS);
-    glDepthMask(GL_TRUE);
+    if (wsgl_current_transparency_pass == 1) {
+        glDepthMask(GL_FALSE);
+    } else {
+        glDepthMask(GL_TRUE);
+    }
     glEnable(GL_DEPTH_TEST);
     break;
 

--- a/src/libphigs/wsgl/wsgl_attr.c
+++ b/src/libphigs/wsgl/wsgl_attr.c
@@ -412,7 +412,8 @@ void wsgl_set_asf(
  */
 void wsgl_set_colr(
                    Pint colr_type,
-                   Pcoval *colr
+                   Pcoval *colr,
+                   Pfloat alpha
                    )
 {
   int* crash = 0;
@@ -430,12 +431,12 @@ void wsgl_set_colr(
                        colr->direct.rgb.red,
                        colr->direct.rgb.green,
                        colr->direct.rgb.blue,
-                       1.0);
+                       alpha);
     } else {
       glColor4f(colr->direct.rgb.red,
                 colr->direct.rgb.green,
                 colr->direct.rgb.blue,
-                1.0);
+                alpha);
     }
     break;
 

--- a/src/libphigs/wsgl/wsgl_extattr.c
+++ b/src/libphigs/wsgl/wsgl_extattr.c
@@ -489,33 +489,33 @@ void wsgl_setup_int_reflectance_model(
       ambient[0] = colr->direct.rgb.red   * refl_props->ambient_coef;
       ambient[1] = colr->direct.rgb.green * refl_props->ambient_coef;
       ambient[2] = colr->direct.rgb.blue  * refl_props->ambient_coef;
-      ambient[3] = 1.0;
+      ambient[3] = ast ? ast->alpha_channel : 1.0f;
 
       diffuse[0] = 0.0;
       diffuse[1] = 0.0;
       diffuse[2] = 0.0;
-      diffuse[3] = 1.0;
+      diffuse[3] = ast ? ast->alpha_channel : 1.0f;
 
       specular[0] = 0.0;
       specular[1] = 0.0;
       specular[2] = 0.0;
-      specular[3] = 1.0;
+      specular[3] = ast ? ast->alpha_channel : 1.0f;
     }
     if (colr_type == PMODEL_RGBA) {
       ambient[0] = colr->direct.rgba.red   * refl_props->ambient_coef;
       ambient[1] = colr->direct.rgba.green * refl_props->ambient_coef;
       ambient[2] = colr->direct.rgba.blue  * refl_props->ambient_coef;
-      ambient[3] = 1.;
+      ambient[3] = colr->direct.rgba.alpha;
 
       diffuse[0] = 0.0;
       diffuse[1] = 0.0;
       diffuse[2] = 0.0;
-      diffuse[3] = 1.0;
+      diffuse[3] = colr->direct.rgba.alpha;
 
       specular[0] = 0.0;
       specular[1] = 0.0;
       specular[2] = 0.0;
-      specular[3] = 1.0;
+      specular[3] = colr->direct.rgba.alpha;
     }
     break;
 
@@ -527,33 +527,33 @@ void wsgl_setup_int_reflectance_model(
       ambient[0] = colr->direct.rgb.red   * refl_props->ambient_coef;
       ambient[1] = colr->direct.rgb.green * refl_props->ambient_coef;
       ambient[2] = colr->direct.rgb.blue  * refl_props->ambient_coef;
-      ambient[3] = 1.0;
+      ambient[3] = ast ? ast->alpha_channel : 1.0f;
 
       diffuse[0] = colr->direct.rgb.red   * refl_props->diffuse_coef;
       diffuse[1] = colr->direct.rgb.green * refl_props->diffuse_coef;
       diffuse[2] = colr->direct.rgb.blue  * refl_props->diffuse_coef;
-      diffuse[3] = 1.0;
+      diffuse[3] = ast ? ast->alpha_channel : 1.0f;
 
       specular[0] = 0.0;
       specular[1] = 0.0;
       specular[2] = 0.0;
-      specular[3] = 1.0;
+      specular[3] = ast ? ast->alpha_channel : 1.0f;
     }
     if (colr_type == PMODEL_RGBA) {
       ambient[0] = colr->direct.rgba.red   * refl_props->ambient_coef;
       ambient[1] = colr->direct.rgba.green * refl_props->ambient_coef;
       ambient[2] = colr->direct.rgba.blue  * refl_props->ambient_coef;
-      ambient[3] = 1.0;
+      ambient[3] = colr->direct.rgba.alpha;
 
       diffuse[0] = colr->direct.rgba.red   * refl_props->diffuse_coef;
       diffuse[1] = colr->direct.rgba.green * refl_props->diffuse_coef;
       diffuse[2] = colr->direct.rgba.blue  * refl_props->diffuse_coef;
-      diffuse[3] = 1.0;
+      diffuse[3] = colr->direct.rgba.alpha;
 
       specular[0] = 0.0;
       specular[1] = 0.0;
       specular[2] = 0.0;
-      specular[3] = 1.0;
+      specular[3] = colr->direct.rgba.alpha;
     }
     break;
 
@@ -565,33 +565,33 @@ void wsgl_setup_int_reflectance_model(
       ambient[0] = colr->direct.rgb.red   * refl_props->ambient_coef;
       ambient[1] = colr->direct.rgb.green * refl_props->ambient_coef;
       ambient[2] = colr->direct.rgb.blue  * refl_props->ambient_coef;
-      ambient[3] = 1.0;
+      ambient[3] = ast ? ast->alpha_channel : 1.0f;
 
       diffuse[0] = colr->direct.rgb.red   * refl_props->diffuse_coef;
       diffuse[1] = colr->direct.rgb.green * refl_props->diffuse_coef;
       diffuse[2] = colr->direct.rgb.blue  * refl_props->diffuse_coef;
-      diffuse[3] = 1.0;
+      diffuse[3] = ast ? ast->alpha_channel : 1.0f;
 
       specular[0] = colr->direct.rgb.red   * refl_props->specular_coef;
       specular[1] = colr->direct.rgb.green * refl_props->specular_coef;
       specular[2] = colr->direct.rgb.blue  * refl_props->specular_coef;
-      specular[3] = 1.0;
+      specular[3] = ast ? ast->alpha_channel : 1.0f;
     }
     if (colr_type == PMODEL_RGBA) {
       ambient[0] = colr->direct.rgba.red   * refl_props->ambient_coef;
       ambient[1] = colr->direct.rgba.green * refl_props->ambient_coef;
       ambient[2] = colr->direct.rgba.blue  * refl_props->ambient_coef;
-      ambient[3] = 1.0;
+      ambient[3] = colr->direct.rgba.alpha;
 
       diffuse[0] = colr->direct.rgba.red   * refl_props->diffuse_coef;
       diffuse[1] = colr->direct.rgba.green * refl_props->diffuse_coef;
       diffuse[2] = colr->direct.rgba.blue  * refl_props->diffuse_coef;
-      diffuse[3] = 1.0;
+      diffuse[3] = colr->direct.rgba.alpha;
 
       specular[0] = colr->direct.rgba.red   * refl_props->specular_coef;
       specular[1] = colr->direct.rgba.green * refl_props->specular_coef;
       specular[2] = colr->direct.rgba.blue  * refl_props->specular_coef;
-      specular[3] = 1.0;
+      specular[3] = colr->direct.rgba.alpha;
     }
 #ifdef DEBUGLIGHT
     else printf("Reflectance model, color type is not RGB %d \n", colr_type);
@@ -605,9 +605,9 @@ void wsgl_setup_int_reflectance_model(
     memset(ambient, 0.0, sizeof(Pfloat) * 3);
     memset(diffuse, 0.0, sizeof(Pfloat) * 3);
     memset(specular, 0.0, sizeof(Pfloat) * 3);
-    ambient[3] = 1.0;
-    diffuse[3] = 1.0;
-    specular[3] = 1.0;
+    ambient[3] = ast ? ast->alpha_channel : 1.0f;
+    diffuse[3] = ast ? ast->alpha_channel : 1.0f;
+    specular[3] = ast ? ast->alpha_channel : 1.0f;
 
     if (wsgl_use_shaders) glUniform1i(shading_mode, 0);
     break;
@@ -620,7 +620,7 @@ void wsgl_setup_int_reflectance_model(
                        colr->direct.rgb.red,
                        colr->direct.rgb.green,
                        colr->direct.rgb.blue,
-                       1.0);
+                       ast ? ast->alpha_channel : 1.0f);
       break;
     case PMODEL_RGBA:
       glVertexAttrib4f(vCOLOR,
@@ -675,7 +675,7 @@ int wsgl_setup_int_colr(
            colr->direct.rgba.blue,
            colr->direct.rgba.alpha);
 #endif
-    wsgl_set_colr(colr_type, colr);
+    wsgl_set_colr(colr_type, colr, ast ? ast->alpha_channel : 1.0f);
     lighting = FALSE;
   }
 
@@ -735,7 +735,7 @@ int wsgl_setup_back_int_colr(
     lighting = TRUE;
   }
   else {
-    wsgl_set_colr(colr_type, colr);
+    wsgl_set_colr(colr_type, colr, ast ? ast->alpha_channel : 1.0f);
     lighting = FALSE;
   }
 

--- a/src/libphigs/wsgl/wsgl_line.c
+++ b/src/libphigs/wsgl/wsgl_line.c
@@ -51,6 +51,12 @@ void wsgl_polyline(
    point_list.points = (Ppoint *) &data[1];
 
    wsgl_setup_line_attr(ast);
+   {
+       GLfloat cur_color[4];
+       glGetFloatv(GL_CURRENT_COLOR, cur_color);
+       if (wsgl_current_transparency_pass == 0 && cur_color[3] < 1.0f) return;
+       if (wsgl_current_transparency_pass == 1 && cur_color[3] >= 1.0f) return;
+   }
    glBegin(GL_LINES);
    for (i = 0; i < point_list.num_points; i++) {
       glVertex2f(point_list.points[i].x,
@@ -91,6 +97,12 @@ void wsgl_polyline3(
    point_list.points = (Ppoint3 *) &data[1];
 
    wsgl_setup_line_attr(ast);
+   {
+       GLfloat cur_color[4];
+       glGetFloatv(GL_CURRENT_COLOR, cur_color);
+       if (wsgl_current_transparency_pass == 0 && cur_color[3] < 1.0f) return;
+       if (wsgl_current_transparency_pass == 1 && cur_color[3] >= 1.0f) return;
+   }
    glBegin(GL_LINES);
    for (i = 0; i < point_list.num_points; i++) {
       glVertex3f(point_list.points[i].x,

--- a/src/libphigs/wsgl/wsgl_marker.c
+++ b/src/libphigs/wsgl/wsgl_marker.c
@@ -225,6 +225,12 @@ void wsgl_polymarker(
    point_list.points = (Ppoint *) &data[1];
 
    wsgl_setup_marker_attr(ast, &type, &size);
+   {
+       GLfloat cur_color[4];
+       glGetFloatv(GL_CURRENT_COLOR, cur_color);
+       if (wsgl_current_transparency_pass == 0 && cur_color[3] < 1.0f) return;
+       if (wsgl_current_transparency_pass == 1 && cur_color[3] >= 1.0f) return;
+   }
    switch (type) {
       case PMARKER_DOT:
 	wsgl_marker_polygon(40, &point_list, size);
@@ -300,6 +306,12 @@ void wsgl_polymarker3(
       }
 
       wsgl_setup_marker_attr(ast, &type, &size);
+      {
+          GLfloat cur_color[4];
+          glGetFloatv(GL_CURRENT_COLOR, cur_color);
+          if (wsgl_current_transparency_pass == 0 && cur_color[3] < 1.0f) return;
+          if (wsgl_current_transparency_pass == 1 && cur_color[3] >= 1.0f) return;
+      }
       switch (type) {
       case PMARKER_DOT:
 	wsgl_marker_polygon(40, &plist, size);

--- a/src/libphigs/wsgl/wsgl_tess.c
+++ b/src/libphigs/wsgl/wsgl_tess.c
@@ -91,10 +91,14 @@ void wsgl_draw_tess_polygon(Wsgl_tess_vertex *vertices, int num_vertices, int re
     int has_transparency = 0;
 
     if (num_vertices > 0 && vertices[0].apply_cb) {
-        if (vertices[0].colr_type == PMODEL_RGBA && vertices[0].colr.direct.rgba.alpha < 1.0f) {
-            has_transparency = 1;
-        } else if (vertices[0].colr_type == PMODEL_RGB && vertices[0].ast && vertices[0].ast->alpha_channel < 1.0f) {
-            has_transparency = 1;
+        for (i = 0; i < num_vertices; i++) {
+            if (vertices[i].colr_type == PMODEL_RGBA && vertices[i].colr.direct.rgba.alpha < 1.0f) {
+                has_transparency = 1;
+                break;
+            } else if (vertices[i].colr_type != PMODEL_RGBA && vertices[i].ast && vertices[i].ast->alpha_channel < 1.0f) {
+                has_transparency = 1;
+                break;
+            }
         }
     } else {
         glGetFloatv(GL_CURRENT_COLOR, cur_color);

--- a/src/libphigs/wsgl/wsgl_tess.c
+++ b/src/libphigs/wsgl/wsgl_tess.c
@@ -93,6 +93,8 @@ void wsgl_draw_tess_polygon(Wsgl_tess_vertex *vertices, int num_vertices, int re
     if (num_vertices > 0 && vertices[0].apply_cb) {
         if (vertices[0].colr_type == PMODEL_RGBA && vertices[0].colr.direct.rgba.alpha < 1.0f) {
             has_transparency = 1;
+        } else if (vertices[0].colr_type == PMODEL_RGB && vertices[0].ast && vertices[0].ast->alpha_channel < 1.0f) {
+            has_transparency = 1;
         }
     } else {
         glGetFloatv(GL_CURRENT_COLOR, cur_color);

--- a/src/libphigs/wsgl/wsgl_tess.c
+++ b/src/libphigs/wsgl/wsgl_tess.c
@@ -87,23 +87,9 @@ void wsgl_draw_tess_polygon(Wsgl_tess_vertex *vertices, int num_vertices, int re
     int normal_indices[MAX_VERTICES];
     int n_vertices = 0;
     int n_normals = 0;
-    GLboolean orig_depth_mask;
     GLfloat cur_color[4];
     int has_transparency = 0;
 
-    tess = gluNewTess();
-    if (!tess) return;
-
-    gluTessCallback(tess, GLU_TESS_BEGIN, (void (CALLBACK *)())tessBeginCB);
-    gluTessCallback(tess, GLU_TESS_END, (void (CALLBACK *)())tessEndCB);
-    gluTessCallback(tess, GLU_TESS_VERTEX, (void (CALLBACK *)())tessVertexCB);
-    gluTessCallback(tess, GLU_TESS_ERROR, (void (CALLBACK *)())tessErrorCB);
-    gluTessCallback(tess, GLU_TESS_COMBINE, (void (CALLBACK *)())tessCombineCB);
-    gluTessCallback(tess, GLU_TESS_EDGE_FLAG, (void (CALLBACK *)())tessEdgeFlagCB);
-
-    /* Determine if depth writing should be disabled for order-independent transparency */
-    glGetBooleanv(GL_DEPTH_WRITEMASK, &orig_depth_mask);
-    
     if (num_vertices > 0 && vertices[0].apply_cb) {
         if (vertices[0].colr_type == PMODEL_RGBA && vertices[0].colr.direct.rgba.alpha < 1.0f) {
             has_transparency = 1;
@@ -114,10 +100,19 @@ void wsgl_draw_tess_polygon(Wsgl_tess_vertex *vertices, int num_vertices, int re
             has_transparency = 1;
         }
     }
-    
-    if (has_transparency && orig_depth_mask == GL_TRUE) {
-        glDepthMask(GL_FALSE);
-    }
+
+    if (wsgl_current_transparency_pass == 0 && has_transparency) return;
+    if (wsgl_current_transparency_pass == 1 && !has_transparency) return;
+
+    tess = gluNewTess();
+    if (!tess) return;
+
+    gluTessCallback(tess, GLU_TESS_BEGIN, (void (CALLBACK *)())tessBeginCB);
+    gluTessCallback(tess, GLU_TESS_END, (void (CALLBACK *)())tessEndCB);
+    gluTessCallback(tess, GLU_TESS_VERTEX, (void (CALLBACK *)())tessVertexCB);
+    gluTessCallback(tess, GLU_TESS_ERROR, (void (CALLBACK *)())tessErrorCB);
+    gluTessCallback(tess, GLU_TESS_COMBINE, (void (CALLBACK *)())tessCombineCB);
+    gluTessCallback(tess, GLU_TESS_EDGE_FLAG, (void (CALLBACK *)())tessEdgeFlagCB);
 
     gluTessBeginPolygon(tess, NULL);
     gluTessBeginContour(tess);
@@ -143,10 +138,6 @@ void wsgl_draw_tess_polygon(Wsgl_tess_vertex *vertices, int num_vertices, int re
 
     /* Restore default edge flag state for subsequent rendering */
     glEdgeFlag(GL_TRUE);
-
-    if (has_transparency && orig_depth_mask == GL_TRUE) {
-        glDepthMask(GL_TRUE);
-    }
 
     if (record_geom_flag && n_vertices > 0) {
         wsgl_add_geometry(GEOM_FACE, vertex_indices, normal_indices, n_vertices);

--- a/src/libphigs/wsgl/wsgl_text.c
+++ b/src/libphigs/wsgl/wsgl_text.c
@@ -425,6 +425,12 @@ static void wsgl_text_string(
   int n_vertices = 0;
 
   wsgl_setup_text_attr(ast, &fnt, &char_expan);
+  {
+      GLfloat cur_color[4];
+      glGetFloatv(GL_CURRENT_COLOR, cur_color);
+      if (wsgl_current_transparency_pass == 0 && cur_color[3] < 1.0f) return;
+      if (wsgl_current_transparency_pass == 1 && cur_color[3] >= 1.0f) return;
+  }
   char_ht = ast->char_ht;
 
   posa.x = text->pos.x;
@@ -496,6 +502,12 @@ static void wsgl_text_string3(
   int n_vertices = 0;
 
   wsgl_setup_text_attr(ast, &fnt, &char_expan);
+  {
+      GLfloat cur_color[4];
+      glGetFloatv(GL_CURRENT_COLOR, cur_color);
+      if (wsgl_current_transparency_pass == 0 && cur_color[3] < 1.0f) return;
+      if (wsgl_current_transparency_pass == 1 && cur_color[3] >= 1.0f) return;
+  }
   char_ht = ast->char_ht;
 
   posa.x = text->pos.x;
@@ -568,6 +580,12 @@ static void wsgl_anno_text_string3(
   int n_vertices = 0;
 
   wsgl_setup_text_attr(ast, &fnt, &char_expan);
+  {
+      GLfloat cur_color[4];
+      glGetFloatv(GL_CURRENT_COLOR, cur_color);
+      if (wsgl_current_transparency_pass == 0 && cur_color[3] < 1.0f) return;
+      if (wsgl_current_transparency_pass == 1 && cur_color[3] >= 1.0f) return;
+  }
   char_ht = ast->anno_char_ht;
 
   posa.x = text->pos.x;


### PR DESCRIPTION
This PR completely overhauls how order-independent transparency is handled in the rendering pipeline, specifically resolving Issue #34. Previously, a hack toggled the depth mask on a per-polygon basis inside the tessellator, which failed when opaque tracks were drawn *before* the transparent detector boundaries but failed the depth test.

To resolve this properly, this implements a **Multi-Pass rendering strategy**:
1. **Pass 1 (Opaque):** Draws only opaque elements (alpha == 1.0) with depth writing ON. Transparent elements are skipped. (Opaque objects like the yellow tracks render normally and populate the depth buffer).
2. **Pass 2 (Transparent):** Draws only transparent elements (alpha < 1.0) with depth writing OFF. Opaque elements are skipped. (Transparent elements like the blue/red detectors render over the yellow tracks without occluding each other).

Changes include:
- `wsb.c`: Refactored `phg_wsb_traverse_all_postings` into a two-pass architecture.
- `wsgl.c` & `wsgl_attr.c`: Added global `wsgl_current_transparency_pass` tracking and strict depth mask enforcement.
- `wsgl_tess.c`, `wsgl_line.c`, `wsgl_marker.c`, `wsgl_text.c`: Implemented pass-checking skip logic dynamically based on `GL_CURRENT_COLOR` or vertex colors.

@schwicke could you please compile and test this patch on your end with the scene from Issue #34 to verify the occlusion is resolved properly?
