### PR TITLE
FIX: clipping on NVIDIA cards with shaders enabled

### DIFF
--- a/src/libphigs/shaders/vs120.vert
+++ b/src/libphigs/shaders/vs120.vert
@@ -13,6 +13,7 @@ varying vec2 TexCoord;
 void main()
 {
   VertexPosEye = gl_ModelViewMatrix * gl_Vertex;
+  gl_ClipVertex = VertexPosEye;
   Color = vColor;
   Normal = normalize(ModelViewMatrix * vec4(gl_Normal, 1));
   gl_Position = ProjectionMatrix * ModelViewMatrix * gl_Vertex;


### PR DESCRIPTION
Update 1.20 version vertex shader to make clipping work with NVIDIA drivers